### PR TITLE
Fix crash with  process_read_proc_file and uninitialised var

### DIFF
--- a/src/gui/window.c
+++ b/src/gui/window.c
@@ -79,7 +79,7 @@ static void gui_window_draw_attach_process_popup(Gui* gui) {
             list = process_list_init();
         }
         static ProcessPid selected = 0;
-        static char search[129] = "";
+        static char search[128] = "";
         bool any_selected = false;
 
         ImGui_SetNextItemWidth(-FLT_MIN);
@@ -102,19 +102,19 @@ static void gui_window_draw_attach_process_popup(Gui* gui) {
         bool confirmed = false;
         if(ImGui_BeginListBox("###processes", avail)) {
             // FIXME: use clipper
-            char label[257];
+            char label[1500];
             for(size_t i = 0; i < list->processes_count; i++) {
-                Process* process = list->processes[i];
+                const Process* process = list->processes[i];
                 snprintf(
                     label,
                     sizeof(label),
                     "%s (%i, %s, %s)%s%s",
                     process->name[0] ? process->name : "unknown process",
                     process->pid,
-                    process->user ? process->user : "unknown user",
-                    process->executable ? process->executable : "unknown exe",
-                    process->command ? ": " : "",
-                    process->command ? process->command : "");
+                    process->user,
+                    process->executable,
+                    process->command,
+                    process->command);
                 if(search[0] != '\0' && strcasestr(label, search) == NULL) {
                     continue;
                 }
@@ -250,7 +250,7 @@ static void gui_window_draw_toolbar(Gui* gui) {
         snprintf(progress_str, sizeof(progress_str), "%.0f%%", progress * 100);
         ImGui_ProgressBar(progress, progressbar_size, progress_str);
     } else {
-        char label[257] = "No Process Selected";
+        char label[1024] = "No Process Selected";
         const char* command = NULL;
         if(memory_search_process_is_attached(gui->memory_search)) {
             Process* process = memory_search_get_process(gui->memory_search);
@@ -261,8 +261,8 @@ static void gui_window_draw_toolbar(Gui* gui) {
                     "%s (%i, %s, %s)",
                     process->name[0] ? process->name : "unknown process",
                     process->pid,
-                    process->user ? process->user : "unknown user",
-                    process->executable ? process->executable : "unknown exe");
+                    process->user,
+                    process->executable);
                 command = process->command;
             }
         }
@@ -746,7 +746,7 @@ static void gui_window_draw_options_pane(Gui* gui, ImVec2 size) {
             ImGui_TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed);
             ImGui_TableSetupColumn("", ImGuiTableColumnFlags_WidthStretch);
             int32_t temp_int;
-            char temp_str[33];
+            char temp_str[32];
 
             // Value
             ImGui_TableNextRow();
@@ -1024,7 +1024,7 @@ static void gui_window_draw_scratchpad_pane(Gui* gui, ImVec2 size) {
                     ImGui_TableNextColumn();
                     static int32_t editing = -1;
                     if(clip_i == editing) {
-                        char temp_str[33];
+                        char temp_str[32];
                         strlcpy(temp_str, display.value_str, sizeof(temp_str));
                         ImGui_SetNextItemWidth(-FLT_MIN);
                         ImGui_SetKeyboardFocusHere();

--- a/src/gui/window.c
+++ b/src/gui/window.c
@@ -108,12 +108,11 @@ static void gui_window_draw_attach_process_popup(Gui* gui) {
                 snprintf(
                     label,
                     sizeof(label),
-                    "%s (%i, %s, %s)%s%s",
+                    "%s (%i, %s, %s): %s",
                     process->name[0] ? process->name : "unknown process",
                     process->pid,
                     process->user,
                     process->executable,
-                    process->command,
                     process->command);
                 if(search[0] != '\0' && strcasestr(label, search) == NULL) {
                     continue;

--- a/src/gui/window.c
+++ b/src/gui/window.c
@@ -109,12 +109,12 @@ static void gui_window_draw_attach_process_popup(Gui* gui) {
                     label,
                     sizeof(label),
                     "%s (%i, %s, %s): %s",
-                    process->name[0] ? process->name : "unknown process",
+                    *process->name ? process->name : "unknown process",
                     process->pid,
                     process->user,
                     process->executable,
                     process->command);
-                if(search[0] != '\0' && strcasestr(label, search) == NULL) {
+                if(*search && strcasestr(label, search) == NULL) {
                     continue;
                 }
                 ImGui_PushIDInt(process->pid);
@@ -258,7 +258,7 @@ static void gui_window_draw_toolbar(Gui* gui) {
                     label,
                     sizeof(label),
                     "%s (%i, %s, %s)",
-                    process->name[0] ? process->name : "unknown process",
+                    *process->name ? process->name : "unknown process",
                     process->pid,
                     process->user,
                     process->executable);

--- a/src/gui/window.c
+++ b/src/gui/window.c
@@ -102,7 +102,7 @@ static void gui_window_draw_attach_process_popup(Gui* gui) {
         bool confirmed = false;
         if(ImGui_BeginListBox("###processes", avail)) {
             // FIXME: use clipper
-            char label[1500];
+            char label[1024];
             for(size_t i = 0; i < list->processes_count; i++) {
                 const Process* process = list->processes[i];
                 snprintf(

--- a/src/memory/search.h
+++ b/src/memory/search.h
@@ -6,8 +6,8 @@
 #include "type.h"
 
 typedef struct {
-    char address_str[19]; // (64bit = 8byte) * 2hexchars + "0x" + '\0'
-    char value_str[33]; // i64 = 20digit, floats could be more but 32chars are good enough
+    char address_str[32]; // (64bit = 8byte) * 2hexchars + "0x" + '\0'
+    char value_str[32]; // i64 = 20digit, floats could be more but 32chars are good enough
 } MemorySearchValueDisplay;
 
 typedef struct __attribute__((packed)) {

--- a/src/process/process.c
+++ b/src/process/process.c
@@ -138,7 +138,6 @@ Process* process_init(ProcessPid pid) {
         strlcpy(process->command, cmdline, sizeof(process->command));
         free(cmdline);
     }
-    process->command[sizeof(process->command) - 1] = '\0';
 
     snprintf(temp_str, sizeof(temp_str), "/proc/%i", process->pid);
     struct stat process_stat;
@@ -156,7 +155,7 @@ Process* process_init(ProcessPid pid) {
     }
     for(size_t i = 0; i < uid_usernames_count; i++) {
         if(uid_usernames[i].uid == process_stat.st_uid) {
-            snprintf(process->user, sizeof(process->user), "%s", uid_usernames[i].username);
+            strlcpy(process->user, uid_usernames[i].username, sizeof(process->user));
             break;
         }
     }

--- a/src/process/process.c
+++ b/src/process/process.c
@@ -11,7 +11,7 @@ static UidUsername* uid_usernames = NULL;
 static size_t uid_usernames_count = 0;
 
 static void load_uid_usernames(void) {
-    char temp_str[257];
+    char temp_str[256];
     size_t capacity = 1;
     size_t count = 0;
     UidUsername* new_uid_usernames = malloc(sizeof(UidUsername) * capacity);
@@ -60,7 +60,7 @@ static void load_uid_usernames(void) {
 }
 
 static char* process_read_proc_file(Process* process, const char* name) {
-    char temp_str[257];
+    char temp_str[256];
 
     snprintf(temp_str, sizeof(temp_str), "/proc/%i/%s", process->pid, name);
     FILE* file = fopen(temp_str, "r");
@@ -101,9 +101,12 @@ Process* process_init(ProcessPid pid) {
         strlcpy(process->name, name, sizeof(process->name));
         free(name);
     }
+    process->command[0] = '\0';
+    process->executable[0] = '\0';
+    process->user[0] = '\0';
 
     snprintf(temp_str, sizeof(temp_str), "/proc/%i/exe", process->pid);
-    char executable[257];
+    char executable[256];
     res = readlink(temp_str, executable, sizeof(executable));
     if(res < 0) {
         if(res == -1) {
@@ -122,13 +125,20 @@ Process* process_init(ProcessPid pid) {
         res--;
     }
     if(res == 0) {
-        process->executable = NULL;
+        process->executable[0] = '\0';
     } else {
         executable[res] = '\0';
-        process->executable = strdup(executable);
+        strlcpy(process->executable, executable, sizeof(process->executable));
     }
 
-    process->command = process_read_proc_file(process, "cmdline");
+    char* cmdline = process_read_proc_file(process, "cmdline");
+    if(cmdline == NULL) {
+        strlcpy(process->command, "<cannot read cmdline>", sizeof(process->command));
+    } else {
+        strlcpy(process->command, cmdline, sizeof(process->command));
+        free(cmdline);
+    }
+    process->command[sizeof(process->command) - 1] = '\0';
 
     snprintf(temp_str, sizeof(temp_str), "/proc/%i", process->pid);
     struct stat process_stat;
@@ -146,33 +156,17 @@ Process* process_init(ProcessPid pid) {
     }
     for(size_t i = 0; i < uid_usernames_count; i++) {
         if(uid_usernames[i].uid == process_stat.st_uid) {
-            process->user = strdup(uid_usernames[i].username);
+            snprintf(process->user, sizeof(process->user), "%s", uid_usernames[i].username);
             break;
         }
     }
-    if(process->user == NULL) {
-        snprintf(temp_str, sizeof(temp_str), "%i", process_stat.st_uid);
-        process->user = strdup(temp_str);
+    if(!*process->user) {
+        snprintf(process->user, sizeof(process->user), "%i", process_stat.st_uid);
     }
 
     return process;
 }
 
 void process_free(Process* process) {
-    char* executable = process->executable;
-    char* command = process->command;
-    char* user = process->user;
-    process->executable = NULL;
-    process->command = NULL;
-    process->user = NULL;
-    if(executable != NULL) {
-        free(executable);
-    }
-    if(command != NULL) {
-        free(command);
-    }
-    if(user != NULL) {
-        free(user);
-    }
     free(process);
 }

--- a/src/process/process.h
+++ b/src/process/process.h
@@ -5,9 +5,9 @@
 typedef struct {
     ProcessPid pid;
     char name[16];
-    char* executable;
-    char* command;
-    char* user;
+    char executable[256];
+    char command[256];
+    char user[256];
 } Process;
 
 Process* process_init(ProcessPid pid);


### PR DESCRIPTION
When `process_read_proc_file` returns NULL there was a problem later on with uninitialized memory, resulting in a crash. Easily reproducible on bazzite 43 by just opening the process list dialog and trying to exit it by pressing either cancel or ok. Reproducible with and without sudo.

Rebuilt  the Process struct to reduce extra heap allocs and make sure there is always a string to copy to.

Also resized other string arrays to powers of 2 for better memory locality (which probably doesn't matter).

Fixes #4 